### PR TITLE
Fixed navigation bar links to profiles and publications

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,13 +22,13 @@ main_dropdown:
    title: Resources
    items:
      - title: Student Profiles
-       url: /students/
+       url: /students
      - title: Alumni Profiles
-       url: /alumni/
+       url: /alumni
      - title: Faculty Profiles
-       url: /faculty/
+       url: /faculty
      - title: Student Publications
-       url: /publications/       
+       url: /publications
 
 
 offering_menus:


### PR DESCRIPTION
Removed trailing slash that causes navigation bar links to 404 when clicked.